### PR TITLE
Upgrade to Tracks 2.6.0.

### DIFF
--- a/conf.d/downloads
+++ b/conf.d/downloads
@@ -5,7 +5,7 @@ dl() {
     cd $2; curl -L -f -O $PROXY $1; cd -
 }
 
-VERSION="2.5.1"
+VERSION="2.6.0"
 
 SRC="/usr/local/src"
 dl https://github.com/TracksApp/tracks/archive/v${VERSION}.zip $SRC


### PR DESCRIPTION
Fixes TracksApp/tracks#2792.