### PR TITLE
Tracks Appliance V17 Update - Needs Common PR239

### DIFF
--- a/changelog
+++ b/changelog
@@ -2,10 +2,11 @@ turnkey-tracks-17.0 (1) turnkey; urgency=low
 
   * Updating tracks appliance and its dependencies to v17.0.
 
-  * Downloading tracks repository from master since owners of the software
-    are not adding additional releases at the moment.
+  * Downloading tracks repository from 2.6.1 release tag from upstream github repository.
 
   * Changing the ruby version used with the tracks software.
+  
+  * Removing ./ruby-version file from build code to allow end user to chose which ruby version to use.
 
   * Updating tracks.py file to include refactoring done in v17.0 for
     libinithooks.

--- a/changelog
+++ b/changelog
@@ -1,3 +1,17 @@
+turnkey-tracks-17.0 (1) turnkey; urgency=low
+
+  * Updating tracks appliance and its dependencies to v17.0.
+
+  * Downloading tracks repository from master since owners of the software
+    are not adding additional releases at the moment.
+
+  * Changing the ruby version used with the tracks software.
+
+  * Updating tracks.py file to include refactoring done in v17.0 for
+    libinithooks.
+
+ -- Mattalynn Darden <mattie@turnkeylinux.org>  Sat, 10 Dec 2022 15:31:14 +0000
+
 turnkey-tracks-16.1 (1) turnkey; urgency=low
 
   * Updated to latest version of Tracks: v2.5.1.

--- a/changelog
+++ b/changelog
@@ -10,6 +10,8 @@ turnkey-tracks-17.0 (1) turnkey; urgency=low
 
   * Updating tracks.py file to include refactoring done in v17.0 for
     libinithooks.
+    
+  * Tweaking code in common/conf/rails file to remove warnings that popped up about HTTP_PROXY parameter during the appliance build code.
 
  -- Mattalynn Darden <mattie@turnkeylinux.org>  Sat, 10 Dec 2022 15:31:14 +0000
 

--- a/conf.d/downloads
+++ b/conf.d/downloads
@@ -1,4 +1,3 @@
-
 #!/bin/bash -ex
 
 dl() {

--- a/conf.d/downloads
+++ b/conf.d/downloads
@@ -1,3 +1,4 @@
+
 #!/bin/bash -ex
 
 dl() {
@@ -5,8 +6,8 @@ dl() {
     cd $2; curl -L -f -O $PROXY $1; cd -
 }
 
-VERSION="2.7.0"
+VERSION="2.6.1"
 
 SRC="/usr/local/src"
-dl https://github.com/TracksApp/tracks/archive/master.zip $SRC
-
+dl https://github.com/TracksApp/tracks/archive/v${VERSION}.zip $SRC
+mv $SRC/v${VERSION}.zip $SRC/tracks-${VERSION}.zip

--- a/conf.d/downloads
+++ b/conf.d/downloads
@@ -5,9 +5,8 @@ dl() {
     cd $2; curl -L -f -O $PROXY $1; cd -
 }
 
-VERSION="2.6.1"
+VERSION="2.7.0"
 
 SRC="/usr/local/src"
-dl https://github.com/TracksApp/tracks/archive/v${VERSION}.zip $SRC
-mv $SRC/v${VERSION}.zip $SRC/tracks-${VERSION}.zip
+dl https://github.com/TracksApp/tracks/archive/master.zip $SRC
 

--- a/conf.d/main
+++ b/conf.d/main
@@ -11,8 +11,8 @@ ADMIN_PASS=turnkey1
 service mysql start
 
 # install tracks and configure it
-unzip $SRC/master*.zip -d $(dirname $WEBROOT)
-rm $SRC/master*.zip
+unzip $SRC/tracks-*.zip -d $(dirname $WEBROOT)
+rm $SRC/tracks-*.zip
 
 mv $WEBROOT $WEBROOT.orig
 mv $(dirname $WEBROOT)/tracks-* $WEBROOT
@@ -34,7 +34,7 @@ EOF
 
 cp $WEBROOT/config/site.yml.tmpl $WEBROOT/config/site.yml
 
-echo "2.7.6" > $WEBROOT/.ruby-version
+rm $WEBROOT/.ruby-version
 
 cd $WEBROOT
 [ "$FAB_HTTP_PROXY" ] && export HTTP_PROXY=$FAB_HTTP_PROXY

--- a/conf.d/main
+++ b/conf.d/main
@@ -1,3 +1,4 @@
+
 #!/bin/sh -ex
 
 SRC=/usr/local/src
@@ -10,8 +11,8 @@ ADMIN_PASS=turnkey1
 service mysql start
 
 # install tracks and configure it
-unzip $SRC/tracks-*.zip -d $(dirname $WEBROOT)
-rm $SRC/tracks-*.zip
+unzip $SRC/master*.zip -d $(dirname $WEBROOT)
+rm $SRC/master*.zip
 
 mv $WEBROOT $WEBROOT.orig
 mv $(dirname $WEBROOT)/tracks-* $WEBROOT
@@ -33,7 +34,7 @@ EOF
 
 cp $WEBROOT/config/site.yml.tmpl $WEBROOT/config/site.yml
 
-echo "2.7.0" > $WEBROOT/.ruby-version
+echo "2.7.6" > $WEBROOT/.ruby-version
 
 cd $WEBROOT
 [ "$FAB_HTTP_PROXY" ] && export HTTP_PROXY=$FAB_HTTP_PROXY

--- a/conf.d/main
+++ b/conf.d/main
@@ -33,6 +33,8 @@ EOF
 
 cp $WEBROOT/config/site.yml.tmpl $WEBROOT/config/site.yml
 
+echo "2.7.0" > $WEBROOT/.ruby-version
+
 cd $WEBROOT
 [ "$FAB_HTTP_PROXY" ] && export HTTP_PROXY=$FAB_HTTP_PROXY
 bundle --without=test install

--- a/overlay/usr/lib/inithooks/bin/tracks.py
+++ b/overlay/usr/lib/inithooks/bin/tracks.py
@@ -16,7 +16,7 @@ import subprocess
 import bcrypt
 import hashlib
 
-from dialog_wrapper import Dialog
+from libinithooks.dialog_wrapper import Dialog
 from mysqlconf import MySQL
 
 


### PR DESCRIPTION
The PR updates the tracks appliance and its dependencies to v17.0. The code changes update the ruby version used for the tracks appliance to 2.7.6. The tracks.py file is also updated to reflect refactoring done in v17.0 for libinithooks. The tracks software download is changed to install from the master branch instead of tracking releases. This is because the owners of the repository have not been keeping up with releases, but there has been updated to the master branch. Lastly, the changes in the code have been documented in the appliance changelog for future reference. I have also gone through the appliances README.rst to ensure all information and links are still valid and relevant.

I have gone through and tweaked common/conf/rails file to remove parameter warnings that came up during the appliance build code. Code changes can be found at https://github.com/turnkeylinux/common/pull/239