### PR TITLE
Install stable tracks

### DIFF
--- a/changelog
+++ b/changelog
@@ -2,6 +2,8 @@ turnkey-tracks-18.1 (1) turnkey; urgency=low
 
   * v18.1 rebuild - includes latest Debian & TurnKey packages.
 
+  * Update Tracks: v2.7.1.
+
   * fix DB corruption on reboot - closes #1983.
 
   * Adds 'mariadb_admin' DB user - exclusively for use in the Webmin MariaDB
@@ -20,7 +22,7 @@ turnkey-tracks-18.1 (1) turnkey; urgency=low
     - DOSLogDir - use default log dir & fix permissions - closes #1950.
     - Add DOSWhitelist example - commented out.
 
- -- Jeremy Davis <jeremy@turnkeylinux.org>  Thu, 12 Sep 2024 06:35:24 +0000
+ -- Jeremy Davis <jeremy@turnkeylinux.org>  Wed, 25 Sep 2024 05:08:41 +0000
 
 turnkey-tracks-18.0 (1) turnkey; urgency=low
 

--- a/conf.d/downloads
+++ b/conf.d/downloads
@@ -5,9 +5,12 @@ dl() {
     cd $2; curl -L -f -O $PROXY $1; cd -
 }
 
-#VERSION="v2.6.1"
-# follow the lead of others and build from master - it has some sec updates
-VERSION=master
+REPO=TracksApp/tracks
+VERSION=$(gh_releases ${REPO} | grep -iv "ALPHA\|BETA\|RC" | sort -V | tail -1)
+URL="https://github.com/${REPO}/archive/${VERSION}.tar.gz"
+
+# previously releases we very slow, but things have improved now
+#VERSION=master
 
 SRC="/usr/local/src"
 dl https://github.com/TracksApp/tracks/archive/${VERSION}.zip $SRC


### PR DESCRIPTION
Tracks has had a couple of stable releases lately, so move back to stable install. See https://github.com/TracksApp/tracks/releases/